### PR TITLE
Add Base.copy(::ParticleFilterState)

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,6 +6,17 @@ export log_ml_estimate, get_lml_est
 
 using Gen: effective_sample_size, log_ml_estimate, sample_unweighted_traces
 
+# Overwrite copy so that it copies the internal arrays as well.
+function Base.copy(state::ParticleFilterState{U}) where U
+    ParticleFilterState{U}(
+        copy(state.traces),
+        copy(state.new_traces),
+        copy(state.log_weights),
+        state.log_ml_est,
+        copy(state.parents)
+    )
+end
+
 "Replace traces with newly updated traces."
 @inline function update_refs!(state::ParticleFilterState)
     # Swap references

--- a/src/view.jl
+++ b/src/view.jl
@@ -21,6 +21,10 @@ struct ParticleFilterSubState{U,S,I,L}
     parents::SubArray{Int,1,Vector{Int},I,L}
 end
 
+# Unclear how one could copy a substate without copying the whole state.
+Base.copy(::ParticleFilterSubState) =
+    error("Cannot copy a particle filter substate. If needed, copy the whole particle filter state.")
+
 Gen.get_traces(state::ParticleFilterSubState) = state.traces
 Gen.get_log_weights(state::ParticleFilterSubState) = state.log_weights
 


### PR DESCRIPTION
This makes it possible to copy particle filter states using `Base.copy`.  This can be useful for code which wishes to run particle filtering and track intermediate particle filter states.

I also added an error message for if a user tries to copy a particle filter substate (since I wasn't sure how this should behave).  But perhaps there is a sensible implementation for this I haven't thought of?